### PR TITLE
Fixed PR-AWS-TRF-KMS-001: AWS Customer Master Key (CMK) rotation is not enabled

### DIFF
--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -118,5 +118,7 @@ resource "aws_directory_service_directory" "example" {
 }
 
 resource "aws_kms_key" "example" {
-  description = "WorkSpaces example key"
+  description         = "WorkSpaces example key"
+  enable_key_rotation = true
+  Policy              = "`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Principal\": \"*\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::$${local.bucket_name}/*\",\n      \"Condition\": {\n        \"StringEquals\": {\n          \"aws:UserAgent\": \"$${random_string.s3_read_password.result}\"\n        }\n      }\n    }\n  ]\n}`"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-001 

 **Violation Description:** 

 This policy identifies Customer Master Keys (CMKs) that are not enabled with key rotation. AWS KMS (Key Management Service) allows customers to create master keys to encrypt sensitive data in different services. As a security best practice, it is important to rotate the keys periodically so that if the keys are compromised, the data in the underlying service is still secure with the new keys. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html#cfn-kms-key-enablekeyrotation