### PR TITLE
Fixed PR-AWS-TRF-KMS-002: AWS KMS Customer Managed Key not in use

### DIFF
--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -119,4 +119,6 @@ resource "aws_directory_service_directory" "example" {
 
 resource "aws_kms_key" "example" {
   description = "WorkSpaces example key"
+  is_enabled  = true
+  Policy      = "`{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Principal\": \"*\",\n      \"Action\": \"s3:GetObject\",\n      \"Resource\": \"arn:aws:s3:::$${local.bucket_name}/*\",\n      \"Condition\": {\n        \"StringEquals\": {\n          \"aws:UserAgent\": \"$${random_string.s3_read_password.result}\"\n        }\n      }\n    }\n  ]\n}`"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-002 

 **Violation Description:** 

 This policy identifies KMS Customer Managed Keys(CMKs) which are not usable. When you create a CMK, it is enabled by default. If you disable a CMK or schedule it for deletion makes it unusable, it cannot be used to encrypt or decrypt data and AWS KMS does not rotate the backing keys until you re-enable it. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html#cfn-kms-key-enabled